### PR TITLE
Synthea no longer generates numbers in patient names

### DIFF
--- a/src/main/resources/synthea.properties
+++ b/src/main/resources/synthea.properties
@@ -56,7 +56,7 @@ generate.only_dead_patients = false
 generate.track_detailed_transition_metrics = false
 
 # If true, person names have numbers appended to them to make them more obviously fake
-generate.append_numbers_to_person_names = true
+generate.append_numbers_to_person_names = false
 
 # these should add up to 1.0
 # weighting and categories are inspired by the following but there are no specific hard numbers to point to


### PR DESCRIPTION
Changed so that HealthShare doesn't run into any issues indexing these patients